### PR TITLE
feat: Configure absolute imports for src directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "tailwindcss": "3.4.3",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
-import { BackgroundCanvas, Footer, Hero, Main, Navbar, WhatsAppButton } from './components';
-import { ThemeProvider } from './context';
+import { BackgroundCanvas, Footer, Hero, Main, Navbar, WhatsAppButton } from '@components';
+import { ThemeProvider } from '@context';
 
 export const App = () => {
   return (

--- a/src/components/about/AboutSection.tsx
+++ b/src/components/about/AboutSection.tsx
@@ -1,8 +1,8 @@
 import { motion } from 'motion/react';
 import { SummaryText } from './SummaryText';
-import { SectionTitle } from '../shared';
+import { SectionTitle } from '@components/shared';
 import imageSrc from '/images/selfie.png';
-import type { ProfileData } from '../../types';
+import type { ProfileData } from '@types';
 
 const PROFILE_DATA: ProfileData = {
     summary: "",

--- a/src/components/hero/HeroMainCopywriting.tsx
+++ b/src/components/hero/HeroMainCopywriting.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
-import { getHeroMainCopywriting } from '../../helpers';
-import { GradientText } from '../shared';
-import type { CopywritingItem } from '../../types';
+import { getHeroMainCopywriting } from '@helpers';
+import { GradientText } from '@components/shared';
+import type { CopywritingItem } from '@types';
 
 const fadeInVariants = {
     hidden: { opacity: 0 },

--- a/src/components/navbar/Logo.tsx
+++ b/src/components/navbar/Logo.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { ThemeContext } from '../../context';
+import { ThemeContext } from '@context';
 import logoDark from '/images/logo_dark.png';
 import logoLight from '/images/logo_light.png';
 

--- a/src/components/navbar/MobileMenuButton.tsx
+++ b/src/components/navbar/MobileMenuButton.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import type { MobileMenuButtonProps } from '../../types';
-import { BootstrapIcon } from '../shared/BootstrapIcon';
+import type { MobileMenuButtonProps } from '@types';
+import { BootstrapIcon } from '@components/shared/BootstrapIcon';
 
 export const MobileMenuButton: React.FC<MobileMenuButtonProps> = ({ onClick }) => {
     const [open, setOpen] = useState(false);

--- a/src/components/navbar/NavLinks.tsx
+++ b/src/components/navbar/NavLinks.tsx
@@ -1,7 +1,7 @@
 import { motion, AnimatePresence } from 'framer-motion';
 import { ThemeToggleButton } from './ThemeToggleButton';
-import { SocialLinkButtons } from '../shared';
-import type { NavLink } from '../../types';
+import { SocialLinkButtons } from '@components/shared';
+import type { NavLink } from '@types';
 
 const navLinks: NavLink[] = [
     {

--- a/src/components/navbar/ThemeToggleButton.tsx
+++ b/src/components/navbar/ThemeToggleButton.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
-import { ThemeContext } from '../../context';
-import { BootstrapIcon } from '../shared/BootstrapIcon';
+import { ThemeContext } from '@context';
+import { BootstrapIcon } from '@components/shared/BootstrapIcon';
 
 export const ThemeToggleButton: React.FC<{ className?: string }> = ({ className }) => {
     const context = useContext(ThemeContext);

--- a/src/components/portfolio/CaseStudyModal.tsx
+++ b/src/components/portfolio/CaseStudyModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { motion } from 'framer-motion';
-import type { CaseStudyModalProps, Visual } from "../../types";
+import type { CaseStudyModalProps, Visual } from "@types";
 
 const ProjectSection: React.FC<{ title: string; content: string }> = ({ title, content }) => (
     <div className="mb-6">

--- a/src/components/portfolio/FilterBar.tsx
+++ b/src/components/portfolio/FilterBar.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion';
-import type { FilterBarProps, ProjectPlatform, ProjectType } from "../../types";
+import type { FilterBarProps, ProjectPlatform, ProjectType } from "@types";
 
 export const FilterBar: React.FC<FilterBarProps> = ({
     currentType,

--- a/src/components/portfolio/PortfolioSection.tsx
+++ b/src/components/portfolio/PortfolioSection.tsx
@@ -2,9 +2,9 @@ import { useState } from 'react';
 import { motion } from 'framer-motion';
 import { ProjectGrid } from './ProjectGrid';
 import { CaseStudyModal } from './CaseStudyModal';
-import { SectionTitle } from '../shared';
+import { SectionTitle } from '@components/shared';
 import imageSrc from "/images/william-hook-apps-unsplash.jpg";
-import type { MethodologyItem, ProjectItem } from '../../types';
+import type { MethodologyItem, ProjectItem } from '@types';
 
 const allProjectsData: ProjectItem[] = [
     {

--- a/src/components/portfolio/ProjectCard.tsx
+++ b/src/components/portfolio/ProjectCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { motion } from "framer-motion";
-import type { ProjectCardProps } from "../../types";
+import type { ProjectCardProps } from "@types";
 
 export const ProjectCard: React.FC<ProjectCardProps> = ({ project, onViewDetails }) => {
     const [isHovered, setIsHovered] = useState(false);

--- a/src/components/portfolio/ProjectGrid.tsx
+++ b/src/components/portfolio/ProjectGrid.tsx
@@ -1,6 +1,6 @@
 import { ProjectCard } from './ProjectCard';
 import { motion } from 'framer-motion';
-import type { ProjectGridProps } from '../../types';
+import type { ProjectGridProps } from '@types';
 
 
 export const ProjectGrid: React.FC<ProjectGridProps> = ({ projects, onProjectClick }) => {

--- a/src/components/portfolio/Testimonials.tsx
+++ b/src/components/portfolio/Testimonials.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion';
-import type { TestimonialItem, TestimonialsProps } from "../../types";
+import type { TestimonialItem, TestimonialsProps } from "@types";
 
 export const Testimonials: React.FC<TestimonialsProps> = ({ testimonials, displayMode = 'grid' }) => {
     if (!testimonials || testimonials.length === 0) {

--- a/src/components/services/CarouselOfTechnologies.tsx
+++ b/src/components/services/CarouselOfTechnologies.tsx
@@ -1,4 +1,4 @@
-import { Carousel } from '../shared';
+import { Carousel } from '@components/shared';
 import { motion } from 'framer-motion';
 import reactNativeLight from '/images/reactjs-svgrepo-light.svg';
 import reactNativeDark from '/images/reactjs-svgrepo-dark.svg';
@@ -13,7 +13,7 @@ import mongo from '/images/mongo-svgrepo.svg';
 import awsDark from '/images/aws-svgrepo-dark.svg';
 import awsLight from '/images/aws-svgrepo-light.svg';
 import linux from '/images/tux.svg';
-import type { CarouselItem } from '../../types';
+import type { CarouselItem } from '@types';
 
 export const CarouselOfTechnologies: React.FC = () => {
     const brands: CarouselItem[] = [

--- a/src/components/services/ServiceCard.tsx
+++ b/src/components/services/ServiceCard.tsx
@@ -1,6 +1,6 @@
 import { motion } from "motion/react";
-import { GradientText } from "../shared";
-import type { ServiceCardProps } from "../../types";
+import { GradientText } from "@components/shared";
+import type { ServiceCardProps } from "@types";
 
 export const ServiceCard: React.FC<ServiceCardProps> = ({ icons, title, description, benefits, delay }) => (
     <motion.div

--- a/src/components/services/ServicesGrid.tsx
+++ b/src/components/services/ServicesGrid.tsx
@@ -1,6 +1,6 @@
-import { BootstrapIcon } from '../shared';
+import { BootstrapIcon } from '@components/shared';
 import { ServiceCard } from './ServiceCard';
-import type { ServiceItem } from '../../types';
+import type { ServiceItem } from '@types';
 
 const services: ServiceItem[] = [
     {

--- a/src/components/services/ServicesSection.tsx
+++ b/src/components/services/ServicesSection.tsx
@@ -1,9 +1,9 @@
 import { motion } from 'motion/react';
 import { ServicesGrid } from './ServicesGrid';
 import { CarouselOfTechnologies } from './CarouselOfTechnologies';
-import { SectionTitle } from '../shared';
+import { SectionTitle } from '@components/shared';
 import imageSrc from '/images/pexels-mikhail-nilov-7989239.jpg';
-import type { MethodologyItem } from '../../types';
+import type { MethodologyItem } from '@types';
 
 const methodologyItems: MethodologyItem[] = [
     { id: 1, text: 'Comunicación clara, transparente y disponible' },

--- a/src/components/shared/BootstrapIcon.tsx
+++ b/src/components/shared/BootstrapIcon.tsx
@@ -1,4 +1,4 @@
-import type { IconProps } from "../../types";
+import type { IconProps } from "@types";
 
 export const BootstrapIcon = ({ name, className }: IconProps) => {
     return <i className={`bi bi-${name} ${className}`}></i>;

--- a/src/components/shared/CTA.tsx
+++ b/src/components/shared/CTA.tsx
@@ -1,4 +1,4 @@
-import type { CTAProps } from "../../types";
+import type { CTAProps } from "@types";
 
 export const CTA: React.FC<CTAProps> = ({
     primaryLabel = "Agendar llamada",

--- a/src/components/shared/Carousel.tsx
+++ b/src/components/shared/Carousel.tsx
@@ -1,6 +1,6 @@
 import { useContext } from "react";
-import { ThemeContext } from "../../context";
-import type { CarouselProps } from "../../types";
+import { ThemeContext } from "@context";
+import type { CarouselProps } from "@types";
 
 const VISIBLE_ITEMS_DESKTOP = 10;
 const VISIBLE_ITEMS_TABLET = 5;

--- a/src/components/shared/GradientText.tsx
+++ b/src/components/shared/GradientText.tsx
@@ -1,4 +1,4 @@
-import type { GradientTextProps } from "../../types";
+import type { GradientTextProps } from "@types";
 
 export const GradientText: React.FC<GradientTextProps> = ({ children, className = "" }) => {
     return (

--- a/src/components/shared/SectionHeader.tsx
+++ b/src/components/shared/SectionHeader.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'motion/react';
 import { GradientText } from './GradientText';
-import type { ServicesHeaderProps } from '../../types';
+import type { ServicesHeaderProps } from '@types';
 
 export const SectionHeader: React.FC<ServicesHeaderProps> = ({ title, subtitle }) => (
     <motion.header

--- a/src/components/shared/SectionMethodology.tsx
+++ b/src/components/shared/SectionMethodology.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'motion/react';
-import type { MethodologyProps } from "../../types";
+import type { MethodologyProps } from "@types";
 
 export const SectionMethodology: React.FC<MethodologyProps> = ({ items, title }) => (
     <motion.section

--- a/src/components/shared/SectionTitle.tsx
+++ b/src/components/shared/SectionTitle.tsx
@@ -1,7 +1,7 @@
 import { motion } from "motion/react";
 import { SectionHeader } from "./SectionHeader";
 import { SectionMethodology } from "./SectionMethodology";
-import type { SectionTitleProps } from "../../types";
+import type { SectionTitleProps } from "@types";
 
 export const SectionTitle: React.FC<SectionTitleProps> = ({
     headerTitle,

--- a/src/components/shared/SocialLinkButtons.tsx
+++ b/src/components/shared/SocialLinkButtons.tsx
@@ -1,5 +1,5 @@
 import { motion } from "motion/react";
-import { getSocialLinks } from "../../helpers";
+import { getSocialLinks } from "@helpers";
 import { BootstrapIcon } from "./BootstrapIcon";
 
 export const SocialLinkButtons = () => {

--- a/src/components/ui/BackgroundCanvas.tsx
+++ b/src/components/ui/BackgroundCanvas.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useContext } from 'react';
-import { ThemeContext } from '../../context';
-import type { CanvasPoint } from '../../types';
+import { ThemeContext } from '@context';
+import type { CanvasPoint } from '@types';
 
 export const BackgroundCanvas = () => {
   const canvasRef: React.RefObject<HTMLCanvasElement> = useRef<HTMLCanvasElement>(null);

--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -1,9 +1,9 @@
 import { useContext } from 'react';
 import { motion } from 'motion/react';
-import { FooterCopyright, ContactForm } from '../footer';
+import { FooterCopyright, ContactForm } from '@components/footer';
 import contactDark from '/images/erica-steeves-G_lwAp0TF38-unsplash-rb.jpg';
 import contactLight from '/images/erica-steeves-G_lwAp0TF38-unsplash-rb.jpg';
-import { ThemeContext } from '../../context';
+import { ThemeContext } from '@context';
 
 export const Footer: React.FC = () => {
     const context = useContext(ThemeContext);

--- a/src/components/ui/Hero.tsx
+++ b/src/components/ui/Hero.tsx
@@ -1,4 +1,4 @@
-import { HeroMainCopywriting, HeroImage } from "../hero";
+import { HeroMainCopywriting, HeroImage } from "@components/hero";
 
 export const Hero: React.FC = ({ }) => {
     return (

--- a/src/components/ui/Main.tsx
+++ b/src/components/ui/Main.tsx
@@ -1,6 +1,6 @@
-import { AboutSection } from "../about";
-import { PortfolioSection } from "../portfolio";
-import { ServicesSection } from "../services";
+import { AboutSection } from "@components/about";
+import { PortfolioSection } from "@components/portfolio";
+import { ServicesSection } from "@components/services";
 
 export const Main: React.FC = ({ }) => {
     return (

--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'motion/react';
-import { Logo, MobileMenuButton, NavLinks, ThemeToggleButton } from '../navbar';
+import { Logo, MobileMenuButton, NavLinks, ThemeToggleButton } from '@components/navbar';
 
 export const Navbar: React.FC = () => {
     const [open, setOpen] = useState(false);

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useState, useEffect } from 'react';
-import type { ThemeContextType, ThemeProviderProps } from '../types';
+import type { ThemeContextType, ThemeProviderProps } from '@types';
 
 export const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 

--- a/src/helpers/getHeroMainCopywriting.ts
+++ b/src/helpers/getHeroMainCopywriting.ts
@@ -1,4 +1,4 @@
-import type { MainCopywritingText } from "../types";
+import type { MainCopywritingText } from "@types";
 
 export const getHeroMainCopywriting = async (): Promise<MainCopywritingText> => {
     return [

--- a/src/helpers/getSocialLinks.ts
+++ b/src/helpers/getSocialLinks.ts
@@ -1,4 +1,4 @@
-import type { SocialLink } from "../types";
+import type { SocialLink } from "@types";
 
 export const getSocialLinks = (): SocialLink[] => {
     return [

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -21,7 +21,17 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+
+    /* Absolute imports */
+    "baseUrl": "./src",
+    "paths": {
+      "@components/*": ["components/*"],
+      "@context/*": ["context/*"],
+      "@helpers/*": ["helpers/*"],
+      "@styles/*": ["styles/*"],
+      "@types/*": ["types/*"]
+    }
   },
   "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import tsconfigPaths from 'vite-tsconfig-paths'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tsconfigPaths()],
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1063,7 +1063,7 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
-debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.4.0:
+debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.4.0:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.1.tgz#e5a8bc6cbc4c6cd3e64308b0693a3d4fa550189b"
   integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
@@ -1629,6 +1629,11 @@ globby@^11.1.0:
     ignore "^5.2.0"
     merge2 "^1.4.1"
     slash "^3.0.0"
+
+globrex@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
+  integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
 
 gopd@^1.2.0:
   version "1.2.0"
@@ -2694,6 +2699,11 @@ ts-interface-checker@^0.1.9:
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
+tsconfck@^3.0.3:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/tsconfck/-/tsconfck-3.1.6.tgz#da1f0b10d82237ac23422374b3fce1edb23c3ead"
+  integrity sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==
+
 tslib@^2.4.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
@@ -2768,6 +2778,15 @@ vary@^1, vary@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
+
+vite-tsconfig-paths@^5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz#d9a71106a7ff2c1c840c6f1708042f76a9212ed4"
+  integrity sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==
+  dependencies:
+    debug "^4.1.1"
+    globrex "^0.1.2"
+    tsconfck "^3.0.3"
 
 vite@^6.3.5:
   version "6.3.5"


### PR DESCRIPTION
- I modified tsconfig.app.json to set baseUrl to ./src and defined path aliases for top-level directories:
  - @components/*
  - @context/*
  - @helpers/*
  - @styles/*
  - @types/*

- I installed and configured vite-tsconfig-paths plugin in vite.config.ts to enable Vite to resolve these path aliases.

- I refactored all .ts and .tsx files within the /src directory to use the new absolute imports instead of relative imports for these aliased paths.